### PR TITLE
Prevent id in url showing all profiles

### DIFF
--- a/teknologr/katalogen/views.py
+++ b/teknologr/katalogen/views.py
@@ -50,7 +50,8 @@ def profile(request, member_id):
 
     # User may view consenting profiles or their own
     # NOTE: there is a small security risk here if the members database is not in sync with the LDAP database
-    if person.allow_publish_info or person.username == request.user.username:
+    if ((person.allow_publish_info and person.isValidMember() and not person.dead) or
+        person.username == request.user.username):
         context['person'] = person
         context['functionaries'] = Functionary.objects.filter(member__id=person.id).order_by('-end_date')
         context['groups'] = GroupMembership.objects.filter(member__id=person.id).order_by('-group__end_date')


### PR DESCRIPTION
Prevent people from seeing non-member and dead peoples sites using their id in the url