### PR TITLE
Replace hard-coded URLs with Django reverse ones

### DIFF
--- a/teknologr/api/urls.py
+++ b/teknologr/api/urls.py
@@ -24,9 +24,9 @@ urlpatterns = [
     url(r'^accounts/ldap/(\d+)/$', LDAPAccountView.as_view()),
     url(r'^accounts/ldap/change_pw/(\d+)/$', change_ldap_password),
     url(r'^accounts/bill/(\d+)/$', BILLAccountView.as_view()),
-    url(r'^htkdump/(\d+)?$', htkDump),
-    url(r'^modulendump/$', modulenDump),
-    url(r'^fulldump/$', fullDump),
-    url(r'^activedump/$', activeDump),
+    url(r'^htkdump/(\d+)?$', htkDump, name='api.views.htkDump'),
+    url(r'^modulendump/$', modulenDump, name='api.views.modulenDump'),
+    url(r'^fulldump/$', fullDump, name='api.views.fullDump'),
+    url(r'^activedump/$', activeDump, name='api.views.activeDump'),
     url(r'^membersByMemberType/([A-Z]{2})/(\w+)?$', membersByMemberType)
 ]

--- a/teknologr/katalogen/templates/home.html
+++ b/teknologr/katalogen/templates/home.html
@@ -33,7 +33,7 @@
             <a class="nav-link" href="{% url 'katalogen.views.myprofile' %}">Min Profil</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="/logout/">Logga ut</a>
+            <a class="nav-link" href="{% url 'logout' %}">Logga ut</a>
           </li>
         </ul>
       </div>

--- a/teknologr/members/templates/base.html
+++ b/teknologr/members/templates/base.html
@@ -39,17 +39,17 @@
             Dumpar<span class="caret"></span>
           </a>
           <div class="dropdown-menu">
-            <a class="dropdown-item" href="/api/fulldump/">Full dump</a>
-            <a class="dropdown-item" href="/api/modulendump/">Modulen dump</a>
-            <a class="dropdown-item" href="/api/activedump/" data-toggle="tooltip" title="Lista av medlemmar som är funkkisar eller i kommittéer med aktiva mandat">Aktiva dump</a>
-            <a class="dropdown-item" href="/api/htkdump/?format=json">Full HTK dump</a>
+            <a class="dropdown-item" href="{% url 'api.views.fullDump' %}">Full dump</a>
+            <a class="dropdown-item" href="{% url 'api.views.modulenDump' %}">Modulen dump</a>
+            <a class="dropdown-item" href="{% url 'api.views.activeDump' %}" data-toggle="tooltip" title="Lista av medlemmar som är funkkisar eller i kommittéer med aktiva mandat">Aktiva dump</a>
+            <a class="dropdown-item" href="{% url 'api.views.htkDump' %}?format=json">Full HTK dump</a>
           </div>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="https://wiki.teknologforeningen.fi/itwiki/index.php/Medlemsregister" target="_blank">Info</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/logout/">Logga ut</a>
+          <a class="nav-link" href="{% url 'logout' %}">Logga ut</a>
         </li>
       </ul>
     </div>

--- a/teknologr/teknologr/urls.py
+++ b/teknologr/teknologr/urls.py
@@ -19,7 +19,7 @@ from members.forms import BSAuthForm
 
 urlpatterns = [
     url(r'^login/$', auth_views.LoginView.as_view(template_name='login.html', authentication_form=BSAuthForm)),
-    url(r'^logout/$', auth_views.LogoutView.as_view(next_page='/login/')),
+    url(r'^logout/$', auth_views.LogoutView.as_view(next_page='/login/'), name='logout'),
     url(r'^', include('katalogen.urls')),
     url(r'^admin/', include('members.urls')),
     url(r'^api/', include('api.urls')),


### PR DESCRIPTION
Remove hard-coded URLs from `templates` and replace them with Djangos reverse url lookup methods.