### PR TITLE
Fix Phux year on member display page

### DIFF
--- a/teknologr/katalogen/templates/profile.html
+++ b/teknologr/katalogen/templates/profile.html
@@ -45,8 +45,8 @@
           <tr>
             <th>Phuxår</th>
             <td align="right">
-            {% if person.enrolment_year %}
-              {{person.enrolment_year}}
+            {% if phux_year %}
+              {{phux_year}}
             {% endif %}
             </td>
           </tr>

--- a/teknologr/katalogen/views.py
+++ b/teknologr/katalogen/views.py
@@ -56,6 +56,7 @@ def profile(request, member_id):
         context['functionaries'] = Functionary.objects.filter(member__id=person.id).order_by('-end_date')
         context['groups'] = GroupMembership.objects.filter(member__id=person.id).order_by('-group__end_date')
         context['decorations'] = DecorationOwnership.objects.filter(member__id=person.id).order_by('acquired')
+        context['phux_year'] = person.getPhuxYear()
         return render(request, 'profile.html', context)
     else:
         raise PermissionDenied

--- a/teknologr/members/models.py
+++ b/teknologr/members/models.py
@@ -132,6 +132,10 @@ class Member(SuperClass):
         memberType = self.getMostRecentMemberType()
         return memberType is not None and (memberType.type == "OM" or memberType.type == "ST")
 
+    def getPhuxYear(self):
+        phuxYear = MemberType.objects.filter(member=self).filter(type='PH').order_by('begin_date')
+        return None if len(phuxYear) == 0 else phuxYear[0].begin_date.year
+
 
 class DecorationOwnership(SuperClass):
     member = models.ForeignKey("Member", on_delete=models.CASCADE)


### PR DESCRIPTION
The Phux year was defined as the year a student enters their studies at Aalto.
This year is not defined for everyone, could be fuzzy due to Military service, or diverse other things.

Instead I propose we define it as the set "Phux year".