### PR TITLE
Update distribution on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python:
   - "3.5"


### PR DESCRIPTION
Updated distribution on [Travis CI to Xenial](https://stackoverflow.com/questions/55521832/update-sqlite-in-travis-ci).

Travis CI runs Trusty by default, which is not up to date [Django's SQLite requirements](https://stackoverflow.com/questions/56520658/djangoshowing-improperlyconfigured-error-sqlite-3-8-3-or-later-is-required-f).

This should allow all new CI runs to pass without nasty requirement errors.