### PR TITLE
Registration touchups

### DIFF
--- a/teknologr/members/templates/applicant.html
+++ b/teknologr/members/templates/applicant.html
@@ -72,7 +72,16 @@
 
       <!-- Consents -->
       <div id="consents">
-        {% bootstrap_field form.subscribed_to_modulen form_group_class="form-group" placeholder=False required_css_class="required" bound_css_class="" %}
+        <div class="form-group">
+          <div class="form-check">
+            {% if form.subscribed_to_modulen.errors %}<div class="alert alert-danger">{{ form.subscribed_to_modulen.errors }}</div>{% endif %}
+            <input id="{{ form.subscribed_to_modulen.id_for_label }}" class="form-check-input" type="checkbox" name="{{ form.subscribed_to_modulen.name }}" autocomplete="off">
+            <label class="form-check-label" for="{{ form.subscribed_to_modulen.id_for_label }}">
+              Jag vill få Teknologföreningens medlemstidning Modulen hemskickad
+            </label>
+          </div>
+        </div>
+
         <div class="form-group">
           <div class="form-check">
             {% if form.allow_publish_info.errors %}<div class="alert alert-danger">{{ form.allow_publish_info.errors }}</div>{% endif %}

--- a/teknologr/registration/labels.py
+++ b/teknologr/registration/labels.py
@@ -13,8 +13,8 @@ MEMBERSHIP_FORM_LABELS = {
     'student_id': 'Studienummer',
     'enrolment_year': 'Inskrivningsår vid Aalto-universitetet',
     'motivation': 'Motivering till medlemskapet',
-    'subscribed_to_modulen': 'Jag vill få Teknologföreningens medlemstidning Modulen hemskickad',
-    # Keep this empty as the Bootstrap4 module for Django is not predictable for checkboxes (i.e. manual labelling)
+    # Keep these empty as the Bootstrap4 module for Django is not predictable for checkboxes (i.e. manual labelling)
+    'subscribed_to_modulen': '',
     'allow_publish_info': '',
     'degree_programme_options': 'Studieinriktning',
     'degree_programme': 'Mata in:',

--- a/teknologr/registration/static/css/registration.css
+++ b/teknologr/registration/static/css/registration.css
@@ -8,8 +8,8 @@
 
 :root {
     --black: #000;
-    --teknolog-rod: #b20738;
-    --mork-rod: #490318;
+    --teknolog-red: #b20738;
+    --dark-red: #490318;
 }
 
 a {

--- a/teknologr/registration/static/css/registration.css
+++ b/teknologr/registration/static/css/registration.css
@@ -8,17 +8,17 @@
 
 :root {
     --black: #000;
-    --teknolog-r√∂d: #b20738;
-    --m√rk-r√d: #490318;
+    --teknolog-rod: #b20738;
+    --mork-rod: #490318;
 }
 
 a {
-    color: var(--teknolog-r√∂d);
+    color: var(--teknolog-rod);
     text-decoration: underline;
 }
 
 a:hover {
-    color: var(--m√rk-r√d);
+    color: var(--mork-rod);
     text-decoration: none;
 }
 
@@ -28,7 +28,7 @@ a.a-tooltip {
 }
 
 hr.line-divider {
-    border-top: 12px solid var(--teknolog-r√∂d);
+    border-top: 12px solid var(--teknolog-rod);
 }
 
 body {
@@ -87,5 +87,5 @@ img#tf-logo {
  */
 .form-group.required label:after, strong.required:after {
    content: "*";
-   color: var(--teknolog-r√∂d);
+   color: var(--teknolog-rod);
 }

--- a/teknologr/registration/templates/registration.html
+++ b/teknologr/registration/templates/registration.html
@@ -85,9 +85,27 @@
 
       <!-- Consents -->
       <div id="consents">
-        {% bootstrap_field form.subscribed_to_modulen form_group_class="form-group" placeholder=False required_css_class="required" bound_css_class="" %}
+        <!-- To ensure that the tooltips stays "as a part of the label text" we have to do a small hack and write out the input manually. -->
 
-        <!-- To ensure that the tooltip stays "as a part of the label text" we have to do a small hack and write out the input manually. -->
+        <div class="form-group">
+          <div class="form-check">
+            {% if form.subscribed_to_modulen.errors %}<div class="alert alert-danger">{{ form.subscribed_to_modulen.errors }}</div>{% endif %}
+            <input id="{{ form.subscribed_to_modulen.id_for_label }}" class="form-check-input" type="checkbox" name="{{ form.subscribed_to_modulen.name }}" autocomplete="off">
+            <label class="form-check-label" for="{{ form.subscribed_to_modulen.id_for_label }}">
+              Jag vill få Teknologföreningens medlemstidning Modulen hemskickad
+              <a
+                class="a-tooltip"
+                href="javascript:;"
+                data-toggle="tooltip"
+                data-placement="top"
+                title="Medlemstidningen Modulen skrivs av TFs medlemmar och skickas gratis åt alla medlemmar, dock endast till dem som bor utanför Otnäs."
+              >
+                <i class="fa fa-question-circle" aria-hidden="true"></i>
+              </a>
+            </label>
+          </div>
+        </div>
+
         <div class="form-group">
           <div class="form-check">
             {% if form.allow_publish_info.errors %}<div class="alert alert-danger">{{ form.allow_publish_info.errors }}</div>{% endif %}


### PR DESCRIPTION
Remove ääkköset from CSS in registration form. These borked very quickly...

Also, include a new tooltip for accepting Modulen home in the registration form.