### PR TITLE
Separation of consents

### DIFF
--- a/teknologr/members/templates/applicant.html
+++ b/teknologr/members/templates/applicant.html
@@ -71,24 +71,29 @@
       </div>
 
       <!-- Consents -->
-      <div id="consents">
+      <div id="consents" class="col-md-12">
         <div class="form-group">
           <div class="form-check">
-            {% if form.subscribed_to_modulen.errors %}<div class="alert alert-danger">{{ form.subscribed_to_modulen.errors }}</div>{% endif %}
-            <input id="{{ form.subscribed_to_modulen.id_for_label }}" class="form-check-input" type="checkbox" name="{{ form.subscribed_to_modulen.name }}" autocomplete="off">
-            <label class="form-check-label" for="{{ form.subscribed_to_modulen.id_for_label }}">
-              Jag vill få Teknologföreningens medlemstidning Modulen hemskickad och att mina uppgifter utlämnas till Modulens redaktion
-            </label>
+            <div class="row align-items-center">
+              {% if form.subscribed_to_modulen.errors %}<div class="alert alert-danger">{{ form.subscribed_to_modulen.errors }}</div>{% endif %}
+              <input id="{{ form.subscribed_to_modulen.id_for_label }}" class="form-check-input" type="checkbox" name="{{ form.subscribed_to_modulen.name }}" autocomplete="off">
+              <label class="form-check-label pl-2" for="{{ form.subscribed_to_modulen.id_for_label }}">
+                Jag vill få Teknologföreningens medlemstidning Modulen hemskickad<br />
+                och att mina uppgifter utlämnas till Modulens redaktion
+              </label>
+            </div>
           </div>
         </div>
 
         <div class="form-group">
           <div class="form-check">
-            {% if form.allow_publish_info.errors %}<div class="alert alert-danger">{{ form.allow_publish_info.errors }}</div>{% endif %}
-            <input id="{{ form.allow_publish_info.id_for_label }}" class="form-check-input" type="checkbox" name="{{ form.allow_publish_info.name }}" autocomplete="off">
-            <label class="form-check-label" for="{{ form.allow_publish_info.id_for_label }}">
-              Jag tillåter att mina uppgifter utlämnas till Katalogen
-            </label>
+            <div class="row align-items-center">
+              {% if form.allow_publish_info.errors %}<div class="alert alert-danger">{{ form.allow_publish_info.errors }}</div>{% endif %}
+              <input id="{{ form.allow_publish_info.id_for_label }}" class="form-check-input" type="checkbox" name="{{ form.allow_publish_info.name }}" autocomplete="off">
+              <label class="form-check-label pl-2" for="{{ form.allow_publish_info.id_for_label }}">
+                Jag tillåter att mina uppgifter utlämnas till Katalogen
+              </label>
+            </div>
           </div>
         </div>
       </div>

--- a/teknologr/members/templates/applicant.html
+++ b/teknologr/members/templates/applicant.html
@@ -77,7 +77,7 @@
             {% if form.subscribed_to_modulen.errors %}<div class="alert alert-danger">{{ form.subscribed_to_modulen.errors }}</div>{% endif %}
             <input id="{{ form.subscribed_to_modulen.id_for_label }}" class="form-check-input" type="checkbox" name="{{ form.subscribed_to_modulen.name }}" autocomplete="off">
             <label class="form-check-label" for="{{ form.subscribed_to_modulen.id_for_label }}">
-              Jag vill få Teknologföreningens medlemstidning Modulen hemskickad
+              Jag vill få Teknologföreningens medlemstidning Modulen hemskickad och att mina uppgifter utlämnas till Modulens redaktion
             </label>
           </div>
         </div>
@@ -87,7 +87,7 @@
             {% if form.allow_publish_info.errors %}<div class="alert alert-danger">{{ form.allow_publish_info.errors }}</div>{% endif %}
             <input id="{{ form.allow_publish_info.id_for_label }}" class="form-check-input" type="checkbox" name="{{ form.allow_publish_info.name }}" autocomplete="off">
             <label class="form-check-label" for="{{ form.allow_publish_info.id_for_label }}">
-              Jag tillåter att mina uppgifter utlämnas till Katalogen och Modulens redaktion
+              Jag tillåter att mina uppgifter utlämnas till Katalogen
             </label>
           </div>
         </div>

--- a/teknologr/registration/static/css/registration.css
+++ b/teknologr/registration/static/css/registration.css
@@ -13,12 +13,12 @@
 }
 
 a {
-    color: var(--teknolog-rod);
+    color: var(--teknolog-red);
     text-decoration: underline;
 }
 
 a:hover {
-    color: var(--mork-rod);
+    color: var(--mork-red);
     text-decoration: none;
 }
 
@@ -28,7 +28,7 @@ a.a-tooltip {
 }
 
 hr.line-divider {
-    border-top: 12px solid var(--teknolog-rod);
+    border-top: 12px solid var(--teknolog-red);
 }
 
 body {
@@ -87,5 +87,5 @@ img#tf-logo {
  */
 .form-group.required label:after, strong.required:after {
    content: "*";
-   color: var(--teknolog-rod);
+   color: var(--teknolog-red);
 }

--- a/teknologr/registration/templates/registration.html
+++ b/teknologr/registration/templates/registration.html
@@ -92,7 +92,7 @@
             {% if form.subscribed_to_modulen.errors %}<div class="alert alert-danger">{{ form.subscribed_to_modulen.errors }}</div>{% endif %}
             <input id="{{ form.subscribed_to_modulen.id_for_label }}" class="form-check-input" type="checkbox" name="{{ form.subscribed_to_modulen.name }}" autocomplete="off">
             <label class="form-check-label" for="{{ form.subscribed_to_modulen.id_for_label }}">
-              Jag vill få Teknologföreningens medlemstidning Modulen hemskickad
+              Jag vill få Teknologföreningens medlemstidning Modulen hemskickad och att mina uppgifter utlämnas till Modulens redaktion
               <a
                 class="a-tooltip"
                 href="javascript:;"
@@ -111,7 +111,7 @@
             {% if form.allow_publish_info.errors %}<div class="alert alert-danger">{{ form.allow_publish_info.errors }}</div>{% endif %}
             <input id="{{ form.allow_publish_info.id_for_label }}" class="form-check-input" type="checkbox" name="{{ form.allow_publish_info.name }}" autocomplete="off">
             <label class="form-check-label" for="{{ form.allow_publish_info.id_for_label }}">
-              Jag tillåter att mina uppgifter utlämnas till Katalogen och Modulens redaktion
+              Jag tillåter att mina uppgifter utlämnas till Katalogen
               <a
                 class="a-tooltip"
                 href="javascript:;"

--- a/teknologr/registration/templates/registration.html
+++ b/teknologr/registration/templates/registration.html
@@ -84,44 +84,49 @@
       </div>
 
       <!-- Consents -->
-      <div id="consents">
+      <div id="consents" class="col-md-8">
         <!-- To ensure that the tooltips stays "as a part of the label text" we have to do a small hack and write out the input manually. -->
 
         <div class="form-group">
           <div class="form-check">
-            {% if form.subscribed_to_modulen.errors %}<div class="alert alert-danger">{{ form.subscribed_to_modulen.errors }}</div>{% endif %}
-            <input id="{{ form.subscribed_to_modulen.id_for_label }}" class="form-check-input" type="checkbox" name="{{ form.subscribed_to_modulen.name }}" autocomplete="off">
-            <label class="form-check-label" for="{{ form.subscribed_to_modulen.id_for_label }}">
-              Jag vill få Teknologföreningens medlemstidning Modulen hemskickad och att mina uppgifter utlämnas till Modulens redaktion
-              <a
-                class="a-tooltip"
-                href="javascript:;"
-                data-toggle="tooltip"
-                data-placement="top"
-                title="Medlemstidningen Modulen skrivs av TFs medlemmar och skickas gratis åt alla medlemmar, dock endast till dem som bor utanför Otnäs."
-              >
-                <i class="fa fa-question-circle" aria-hidden="true"></i>
-              </a>
-            </label>
+            <div class="row align-items-center">
+              {% if form.subscribed_to_modulen.errors %}<div class="alert alert-danger">{{ form.subscribed_to_modulen.errors }}</div>{% endif %}
+              <input id="{{ form.subscribed_to_modulen.id_for_label }}" class="form-check-input" type="checkbox" name="{{ form.subscribed_to_modulen.name }}" autocomplete="off">
+              <label class="form-check-label pl-2" for="{{ form.subscribed_to_modulen.id_for_label }}">
+                Jag vill få Teknologföreningens medlemstidning Modulen hemskickad<br />
+                och att mina uppgifter utlämnas till Modulens redaktion
+                <a
+                  class="a-tooltip"
+                  href="javascript:;"
+                  data-toggle="tooltip"
+                  data-placement="top"
+                  title="Medlemstidningen Modulen skrivs av TFs medlemmar och skickas gratis åt alla medlemmar, dock endast till dem som bor utanför Otnäs."
+                >
+                  <i class="fa fa-question-circle" aria-hidden="true"></i>
+                </a>
+              </label>
+            </div>
           </div>
         </div>
 
         <div class="form-group">
           <div class="form-check">
-            {% if form.allow_publish_info.errors %}<div class="alert alert-danger">{{ form.allow_publish_info.errors }}</div>{% endif %}
-            <input id="{{ form.allow_publish_info.id_for_label }}" class="form-check-input" type="checkbox" name="{{ form.allow_publish_info.name }}" autocomplete="off">
-            <label class="form-check-label" for="{{ form.allow_publish_info.id_for_label }}">
-              Jag tillåter att mina uppgifter utlämnas till Katalogen
-              <a
-                class="a-tooltip"
-                href="javascript:;"
-                data-toggle="tooltip"
-                data-placement="top"
-                title="Katalogen är namnet för Teknologföreningens medlemsregister. Kolla länken längst ner på sidan för en registerbeskrivning."
-              >
-                <i class="fa fa-question-circle" aria-hidden="true"></i>
-              </a>
-            </label>
+            <div class="row align-items-center">
+              {% if form.allow_publish_info.errors %}<div class="alert alert-danger">{{ form.allow_publish_info.errors }}</div>{% endif %}
+              <input id="{{ form.allow_publish_info.id_for_label }}" class="form-check-input" type="checkbox" name="{{ form.allow_publish_info.name }}" autocomplete="off">
+              <label class="form-check-label pl-2" for="{{ form.allow_publish_info.id_for_label }}">
+                Jag tillåter att mina uppgifter utlämnas till Katalogen
+                <a
+                  class="a-tooltip"
+                  href="javascript:;"
+                  data-toggle="tooltip"
+                  data-placement="top"
+                  title="Katalogen är namnet för Teknologföreningens medlemsregister. Kolla länken längst ner på sidan för en registerbeskrivning."
+                >
+                  <i class="fa fa-question-circle" aria-hidden="true"></i>
+                </a>
+              </label>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This PR separates the consents from each other, i.e. sets Modulen specific consents and Katalogen consents to own checkboxes.

Additionally:
- This PR fixes CSS variable names to disuse `ääkköset`