### PR TITLE
Fix typo in registration consent

### DIFF
--- a/teknologr/registration/templates/registration.html
+++ b/teknologr/registration/templates/registration.html
@@ -93,7 +93,7 @@
               <input id="{{ form.subscribed_to_modulen.id_for_label }}" class="form-check-input" type="checkbox" name="{{ form.subscribed_to_modulen.name }}" autocomplete="off">
               <label class="form-check-label pl-2" for="{{ form.subscribed_to_modulen.id_for_label }}">
                 Jag vill få Teknologföreningens medlemstidning Modulen hemskickad<br />
-                och att mina uppgifter utlämnas till Modulens redaktion
+                och tillåter att mina uppgifter utlämnas till Modulens redaktion
                 <a
                   class="a-tooltip"
                   href="javascript:;"


### PR DESCRIPTION
Simply fix a typo found in the registration form.