### PR TITLE
Fix consents on admin page

### DIFF
--- a/teknologr/members/templates/applicant.html
+++ b/teknologr/members/templates/applicant.html
@@ -76,7 +76,14 @@
           <div class="form-check">
             <div class="row align-items-center">
               {% if form.subscribed_to_modulen.errors %}<div class="alert alert-danger">{{ form.subscribed_to_modulen.errors }}</div>{% endif %}
-              <input id="{{ form.subscribed_to_modulen.id_for_label }}" class="form-check-input" type="checkbox" name="{{ form.subscribed_to_modulen.name }}" autocomplete="off">
+              <input
+                id="{{ form.subscribed_to_modulen.id_for_label }}"
+                class="form-check-input"
+                type="checkbox"
+                name="{{ form.subscribed_to_modulen.name }}"
+                autocomplete="off"
+                {% if form.subscribed_to_modulen.value %}checked{% endif %}
+              >
               <label class="form-check-label pl-2" for="{{ form.subscribed_to_modulen.id_for_label }}">
                 Jag vill få Teknologföreningens medlemstidning Modulen hemskickad<br />
                 och att mina uppgifter utlämnas till Modulens redaktion
@@ -89,7 +96,14 @@
           <div class="form-check">
             <div class="row align-items-center">
               {% if form.allow_publish_info.errors %}<div class="alert alert-danger">{{ form.allow_publish_info.errors }}</div>{% endif %}
-              <input id="{{ form.allow_publish_info.id_for_label }}" class="form-check-input" type="checkbox" name="{{ form.allow_publish_info.name }}" autocomplete="off">
+              <input
+                id="{{ form.allow_publish_info.id_for_label }}"
+                class="form-check-input"
+                type="checkbox"
+                name="{{ form.allow_publish_info.name }}"
+                autocomplete="off"
+                {% if form.allow_publish_info.value %}checked{% endif %}
+              >
               <label class="form-check-label pl-2" for="{{ form.allow_publish_info.id_for_label }}">
                 Jag tillåter att mina uppgifter utlämnas till Katalogen
               </label>


### PR DESCRIPTION
This PR ensures that all consents can be seen on the admin panel (if given by an applicant).