### PR TITLE
Ldap fix creation mail

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [pep8]
 max-line-length = 119
+
+[flake8]
+max-line-length = 119

--- a/teknologr/api/views.py
+++ b/teknologr/api/views.py
@@ -118,16 +118,17 @@ class LDAPAccountView(APIView):
         with LDAPAccountManager() as lm:
             try:
                 lm.add_account(member, username, password)
-                if mailToUser:
-                    status = mailNewPassword(member, password)
-                    if not status:
-                        return Response("Password changed, failed to send mail", status=500)
             except LDAPError as e:
                 return Response(str(e), status=400)
 
         # Store account details
         member.username = username
         member.save()
+
+        if mailToUser:
+            status = mailNewPassword(member, password)
+            if not status:
+                return Response("Password changed, failed to send mail", status=500)
 
         # TODO: Send mail to user to notify about new account?
 


### PR DESCRIPTION
This PR changes the order in which LDAP password is created for a user to ensure that data is saved even if mail sending fails.

Additionally, `setup.cfg` is updated with `[flake8]` settings as well.