### PR TITLE
Functionary 404 fix

### DIFF
--- a/teknologr/members/models.py
+++ b/teknologr/members/models.py
@@ -194,6 +194,11 @@ class Functionary(SuperClass):
     str_member = property(_get_str_member)
     str_type = property(_get_str_type)
 
+    def _get_funcationary_type_id(self):
+        return self.functionarytype.id
+
+    functionary_type_id = property(_get_funcationary_type_id)
+
     class Meta:
         unique_together = (("member", "functionarytype", "begin_date", "end_date"),)
 

--- a/teknologr/members/templates/member.html
+++ b/teknologr/members/templates/member.html
@@ -220,12 +220,12 @@
               <th>Till</th>
             </tr></thead>
             {% for functionary in functionaries %}
-            <tr>
-              <td><i class="fas fa-times removeFunctionary text-danger" role="button" data-id="{{ functionary.id }}"></i></td>
-              <td><a href="/admin/functionaries/{{functionary.id}}/">{{functionary.functionarytype.name}}</a></td>
-              <td>{{functionary.begin_date}}</td>
-              <td>{{functionary.end_date}}</td>
-            </tr>
+              <tr>
+                <td><i class="fas fa-times removeFunctionary text-danger" role="button" data-id="{{ functionary.id }}"></i></td>
+                <td><a href="/admin/functionaries/{{functionary.functionary_type_id}}/">{{functionary.functionarytype.name}}</a></td>
+                <td>{{functionary.begin_date}}</td>
+                <td>{{functionary.end_date}}</td>
+              </tr>
             {% endfor %}
         </table>
         <ul class="list-inline">


### PR DESCRIPTION
This PR fixes the following issue: https://github.com/Teknologforeningen/teknologr.io/issues/77

Essentially, it implements a getter for `FunctionaryType` id in `Functionary`. This is needed in the member admin view/template for linking to the functionary page, otherwise the `Functionary` objects id is used instead resulting in a `404`.