### PR TITLE
Autofocus usename field on login page

### DIFF
--- a/teknologr/members/forms.py
+++ b/teknologr/members/forms.py
@@ -98,7 +98,9 @@ class MemberTypeForm(BSModelForm):
 
 
 class BSAuthForm(AuthenticationForm):
-    username = CharField(widget=TextInput(attrs={'class': 'form-control', 'placeholder': 'Användarnamn'}))
+    username = CharField(widget=TextInput(attrs={
+        'class': 'form-control', 'placeholder': 'Användarnamn', 'autofocus': 'on'
+    }))
     password = CharField(widget=PasswordInput(attrs={'class': 'form-control', 'placeholder': 'Lösenord'}))
 
 


### PR DESCRIPTION
This PR enabels `autofocus` on the username field for the login page.

Just a small UX improvement.