### PR TITLE
Bugfix: Remove editableSelect() call to missing jquery plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ bin/python:
 migrate: bin/python
 	bin/python teknologr/manage.py migrate
 
+checkmigrations: bin/python
+	bin/python teknologr/manage.py makemigrations --check --dry-run
+
 serve: bin/python
 	bin/python teknologr/manage.py runserver 8888
 

--- a/teknologr/members/templates/member.html
+++ b/teknologr/members/templates/member.html
@@ -291,6 +291,5 @@
 {% block scripts %}
   {{ block.super }}
   <script src="{% static "js/member.js" %}"></script>
-  <script> $('#{{form.degree_programme.id_for_label}}').editableSelect({ effects: 'slide' }); </script>
   <script src="{% static "js/ldap.js" %}"></script>
 {% endblock %}

--- a/teknologr/members/views.py
+++ b/teknologr/members/views.py
@@ -98,6 +98,8 @@ def member(request, member_id):
             for school, programmes in DEGREE_PROGRAMME_CHOICES.items()
             for programme in programmes
     ]
+    context['programmes'].sort()
+
     context['form'] = form
     context['full_name'] = member
 


### PR DESCRIPTION
The alternative would be to load the [Editable Select JQuery plugin](https://github.com/indrimuska/jquery-editable-select), but I think sorting the options alphabetically is good enough in this case.