### PR TITLE
Feature: Add missing decoration list to admin member view

### DIFF
--- a/teknologr/members/static/js/member.js
+++ b/teknologr/members/static/js/member.js
@@ -85,6 +85,25 @@ $(document).ready(function() {
 		});
 	});
 
+	$('#adddecorationform').submit(function(event){
+		var data = $(this).serialize();
+		var request = $.ajax({
+			url: "/api/decorationOwnership/",
+			method: "POST",
+			data: data
+		});
+
+		request.done(function() {
+			location.reload();
+		});
+
+		request.fail(function( jqHXR, textStatus ){
+			alert( "Request failed: " + textStatus + ": " + jqHXR.responseText );
+		});
+
+		event.preventDefault();
+	});
+
 	$('#addfunctionaryform').submit(function(event){
 		var data = $(this).serialize();
 		var request = $.ajax({

--- a/teknologr/members/templates/group.html
+++ b/teknologr/members/templates/group.html
@@ -10,7 +10,7 @@
       <i class="far fa-edit text-info align-self-center icon-20" role="button" data-toggle="modal" data-target="#groupTypeModal"></i>
     </li>
     <li class="list-inline-item">
-      <i id="deleteGroupType" class="fas fa-times text-danger icon-20" role="button" data-id="{{ subgroup.id }}"></i>
+      <i id="deleteGroupType" class="fas fa-times text-danger icon-20" role="button" data-id="{{ grouptype.id }}"></i>
     </li>
   </ul>
   {% include "modals/grouptype.html" with modalname="groupTypeModal" title="Editera grupptyp" groupTypeForm=groupTypeForm grouptype=grouptype only %}

--- a/teknologr/members/templates/member.html
+++ b/teknologr/members/templates/member.html
@@ -206,6 +206,28 @@
 
       <div class="col-md-4">
         <ul class="list-inline">
+          <li class="list-inline-item"><h3>Hedersbetygelser</h3></li>
+          <li class="list-inline-item float-right">
+            <button class="btn btn-sm btn-success" data-toggle="modal" data-target="#addDecoration">Lägg till ny</button>
+            {% include "modals/memberdecoration.html" with modalname="addDecoration" title="Lägg till hedersbetygelse" form=adddecorationform only %}
+          </li>
+        </ul>
+        <table class="table table-sm table-striped table-borderless">
+          <thead><tr>
+              <th></th>
+              <th>Betygelse</th>
+              <th>Datum</th>
+            </tr></thead>
+            {% for ownership in decorations %}
+            <tr>
+              <td><i class="fas fa-times removeGroup text-danger" role="button" data-id="{{ ownership.id }}"></i></td>
+              <td><a href="/admin/decorations/{{ownership.decoration.id}}/">{{ownership.decoration.name}}</a></td>
+              <td>{{ownership.acquired}}</td>
+            </tr>
+            {% endfor %}
+        </table>
+
+        <ul class="list-inline">
           <li class="list-inline-item"><h3>Poster</h3></li>
           <li class="list-inline-item float-right">
             <button class="btn btn-sm btn-success" data-toggle="modal" data-target="#addFunctionary">Lägg till ny</button>
@@ -228,6 +250,7 @@
               </tr>
             {% endfor %}
         </table>
+
         <ul class="list-inline">
           <li class="list-inline-item"><h3>Grupper</h3></li>
           <li class="list-inline-item float-right">
@@ -251,6 +274,7 @@
             </tr>
             {% endfor %}
         </table>
+
         <ul class="list-inline">
           <li class="list-inline-item"><h3>Medlemstyper</h3></li>
           <li class="list-inline-item float-right">

--- a/teknologr/members/templates/member.html
+++ b/teknologr/members/templates/member.html
@@ -220,7 +220,7 @@
             </tr></thead>
             {% for ownership in decorations %}
             <tr>
-              <td><i class="fas fa-times removeGroup text-danger" role="button" data-id="{{ ownership.id }}"></i></td>
+              <td><i class="fas fa-times removeDecoration text-danger" role="button" data-id="{{ ownership.id }}"></i></td>
               <td><a href="/admin/decorations/{{ownership.decoration.id}}/">{{ownership.decoration.name}}</a></td>
               <td>{{ownership.acquired}}</td>
             </tr>

--- a/teknologr/members/templates/modals/memberdecoration.html
+++ b/teknologr/members/templates/modals/memberdecoration.html
@@ -1,0 +1,29 @@
+{% extends "modals/modal.html" %}
+
+{% block modalcontent %}
+<form id="adddecorationform" autocomplete="off">
+  {% csrf_token %}
+  <div class="row form-group">
+    <div class="col-3">
+      <label for={{form.decoration.id_for_label}}>Hedersbetygelse</label>
+    </div>
+    <div class="col-9">
+      {{ form.decoration }}
+    </div>
+  </div>
+  <div class="row form-group">
+    <div class="col-3">
+      <label for={{form.acquired.id_for_label}}>Datum</label>
+    </div>
+    <div class="col-9">
+      {{ form.acquired }}
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <button type="submit" class="btn btn-success float-right">Spara</button>
+    </div>
+  </div>
+  {{ form.member.as_hidden }}
+</form>
+{% endblock %}

--- a/teknologr/members/views.py
+++ b/teknologr/members/views.py
@@ -101,6 +101,10 @@ def member(request, member_id):
     context['form'] = form
     context['full_name'] = member
 
+    # Get decorations
+    context['decorations'] = DecorationOwnership.objects.filter(member__id=member_id).order_by('-acquired')
+    context['adddecorationform'] = DecorationOwnershipForm(initial={'member': member_id})
+
     # Get functionary positions
     context['functionaries'] = Functionary.objects.filter(member__id=member_id)
     context['addfunctionaryform'] = FunctionaryForm(initial={'member': member_id})

--- a/teknologr/members/views.py
+++ b/teknologr/members/views.py
@@ -106,11 +106,11 @@ def member(request, member_id):
     context['adddecorationform'] = DecorationOwnershipForm(initial={'member': member_id})
 
     # Get functionary positions
-    context['functionaries'] = Functionary.objects.filter(member__id=member_id)
+    context['functionaries'] = Functionary.objects.filter(member__id=member_id).order_by('-begin_date')
     context['addfunctionaryform'] = FunctionaryForm(initial={'member': member_id})
 
     # Get groups
-    context['groups'] = GroupMembership.objects.filter(member__id=member_id)
+    context['groups'] = GroupMembership.objects.filter(member__id=member_id).order_by('-group__begin_date')
     context['addgroupform'] = GroupMembershipForm(initial={'member': member_id})
 
     # Get membertypes


### PR DESCRIPTION
 - Added the list of decorations to the admin member view since it was missing
 -  Specified an item order to the posts and groups lists in the admin member view (same as in the non-admin view)
 - Fixed bug where group types could not be deleted using the delete button