### PR TITLE
Automatically set ldap givenName

### DIFF
--- a/teknologr/api/ldap.py
+++ b/teknologr/api/ldap.py
@@ -41,7 +41,8 @@ class LDAPAccountManager:
         attrs['mailHost'] = [b'smtp.ayy.fi']
         attrs['gidNumber'] = [b'1000']
         attrs['sn'] = [member.surname.encode('utf-8')]
-        attrs['givenName'] = [member.preferred_name.encode('utf-8')]
+        given_name = member.preferred_name if member.preferred_name else member.given_names.split()[0]
+        attrs['givenName'] = [given_name.encode('utf-8')]
         attrs['loginShell'] = [b'/bin/bash']
         attrs['objectClass'] = [
             b'kerberosSecurityObject',


### PR DESCRIPTION
The first given name is chosen for the LDAP givenName if the member does not have a preferred name.