### PR TITLE
Add back static JS files to public Katalogen pages

### DIFF
--- a/teknologr/katalogen/templates/home.html
+++ b/teknologr/katalogen/templates/home.html
@@ -85,5 +85,14 @@
       {% endblock %}
 
     </div><!-- /.container -->
+
+
+    <!-- Bootstrap core JavaScript
+    ================================================== -->
+    <!-- Placed at the end of the document so the pages load faster -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script src="{% static 'assets/js/bootstrap.min.js' %}"></script>
+
   </body>
 </html>


### PR DESCRIPTION
JS is needed for the collapsible navbar.
This commit partially reverts 240f8b471d6a8678d17109e6297006111c15ea50