### PR TITLE
LDAP and BILL syncing issues

### DIFF
--- a/teknologr/api/bill.py
+++ b/teknologr/api/bill.py
@@ -61,7 +61,7 @@ class BILLAccountManager:
             raise BILLException(error)
 
         # If the BILL account does not exist all is ok
-        if info.get('exists') == False:
+        if info.get('exists') is False:
             return
 
         result = self.__request(f"del?type=user&acc={bill_code}")

--- a/teknologr/api/ldap.py
+++ b/teknologr/api/ldap.py
@@ -18,24 +18,17 @@ def LDAPError_to_string(e):
 
 def get_ldap_account(username):
     '''
-    Get the info for a certain LDAP account. Does never throw LDAPError.
+    Get the info for a certain LDAP account. Never throws.
     '''
-    result = {
-        'username': username,
-        'exists': False,
-        'groups': [],
-    }
     if not username:
-        return result
+        return {'username': None, 'exists': False, 'groups': []}
     try:
         with LDAPAccountManager() as lm:
             exists = lm.check_account(username)
             groups = lm.get_ldap_groups(username)
-            result['exists'] = exists
-            result['groups'] = groups
+            return {'username': username, 'exists': exists, 'groups': groups}
     except ldap.LDAPError as e:
-        result['error'] = LDAPError_to_string(e)
-    return result
+        return {'username': username, 'error': LDAPError_to_string(e)}
 
 class LDAPAccountManager:
     def __init__(self):

--- a/teknologr/api/ldap.py
+++ b/teknologr/api/ldap.py
@@ -26,7 +26,7 @@ def get_ldap_account(username):
         with LDAPAccountManager() as lm:
             exists = lm.check_account(username)
             groups = lm.get_ldap_groups(username)
-            return {'username': username, 'exists': exists, 'groups': groups}
+            return {'username': username, 'exists': exists, 'groups': sorted(groups)}
     except ldap.LDAPError as e:
         return {'username': username, 'error': LDAPError_to_string(e)}
 

--- a/teknologr/api/ldap.py
+++ b/teknologr/api/ldap.py
@@ -10,7 +10,7 @@ def LDAPError_to_string(e):
     if not isinstance(e, ldap.LDAPError):
         return str(e)
     data = e.args[0]
-    s = f"{data.get('desc' , '')} [{data.get('result')}]"
+    s = f"{data.get('desc' , '')} [LDAP result code {data.get('result')}]"
     info = data.get('info')
     if info:
         s += f' ({info})'

--- a/teknologr/api/views.py
+++ b/teknologr/api/views.py
@@ -262,7 +262,11 @@ class LDAPAccountView(APIView):
         result = {}
         try:
             with LDAPAccountManager() as lm:
-                result = {'username': member.username, 'groups': lm.get_ldap_groups(member.username)}
+                result = {
+                    'username': member.username,
+                    'exists': lm.check_account(member.username),
+                    'groups': lm.get_ldap_groups(member.username),
+                }
         except LDAPError as e:
             return Response(LDAPError_to_string(e), status=400)
 

--- a/teknologr/api/views.py
+++ b/teknologr/api/views.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from datetime import datetime
 from api.serializers import *
 from api.filters import *
-from api.ldap import LDAPAccountManager, LDAPError_to_string
+from api.ldap import LDAPAccountManager, LDAPError_to_string, get_ldap_account
 from api.bill import BILLAccountManager, BILLException
 from api.utils import assert_public_member_fields
 from api.mailutils import mailNewPassword, mailNewAccount
@@ -259,18 +259,7 @@ class MemberTypeViewSet(BaseModelViewSet):
 class LDAPAccountView(APIView):
     def get(self, request, member_id):
         member = get_object_or_404(Member, id=member_id)
-        result = {}
-        try:
-            with LDAPAccountManager() as lm:
-                result = {
-                    'username': member.username,
-                    'exists': lm.check_account(member.username),
-                    'groups': lm.get_ldap_groups(member.username),
-                }
-        except LDAPError as e:
-            return Response(LDAPError_to_string(e), status=400)
-
-        return Response(result, status=200)
+        return Response(get_ldap_account(member.username), status=200)
 
     def post(self, request, member_id):
         # Create LDAP account for given user

--- a/teknologr/api/views.py
+++ b/teknologr/api/views.py
@@ -340,17 +340,7 @@ def change_ldap_password(request, member_id):
 class BILLAccountView(APIView):
     def get(self, request, member_id):
         member = get_object_or_404(Member, id=member_id)
-
-        if not member.bill_code:
-            return Response('Member has no BILL account', status=400)
-
-        bm = BILLAccountManager()
-        try:
-            result = bm.get_bill_info(member.bill_code)
-        except BILLException as e:
-            return Response(str(e), status=400)
-
-        return Response(result, status=200)
+        return Response(BILLAccountManager().get_bill_info(member.bill_code), status=200)
 
     def post(self, request, member_id):
         member = get_object_or_404(Member, id=member_id)

--- a/teknologr/members/models.py
+++ b/teknologr/members/models.py
@@ -267,7 +267,9 @@ class Member(SuperClass):
             from ldap import LDAPError
             try:
                 with LDAPAccountManager() as lm:
-                    lm.change_email(self.username, self.email)
+                    # Skip syncing email to LDAP if the LDAP account does not exist
+                    if lm.check_account(self.username):
+                        lm.change_email(self.username, self.email)
             except LDAPError as e:
                 # Could not update LDAP, save other fields but keep original email
                 self.email = self._original_email

--- a/teknologr/members/static/js/base.js
+++ b/teknologr/members/static/js/base.js
@@ -52,8 +52,8 @@ const add_request_listener = ({ selector, method, url, data, confirmMessage, new
 				else location.reload();
 			});
 			// XXX: The error message is not very helpful for the user, so should probably change this to something else
-			request.fail((jqHXR, textStatus) => {
-				alert(`Request failed (${textStatus}): ${jqHXR.responseText}`);
+			request.fail((jqHXR, _textStatus) => {
+				alert(`Request failed with status ${jqHXR.status} (${jqHXR.statusText}): ${jqHXR.responseText}`);
 			});
 		});
 	});

--- a/teknologr/members/static/js/ldap.js
+++ b/teknologr/members/static/js/ldap.js
@@ -27,7 +27,7 @@ $(document).ready(function() {
     selector: "#delete-ldap-button",
     method: "DELETE",
     url: element => `/api/accounts/ldap/${element.data('id')}/`,
-    confirmMessage: "Vill du ta bort detta LDAP konto?",
+    confirmMessage: "Vill du ta bort detta LDAP-konto?",
   });
   // Change the LDAP password for the selected user
   add_request_listener({
@@ -48,6 +48,6 @@ $(document).ready(function() {
     selector: "#delete-bill-button",
     method: "DELETE",
     url: element => `/api/accounts/bill/${element.data('id')}/`,
-    confirmMessage: "Vill du ta bort detta BILL konto?",
+    confirmMessage: "Vill du ta bort detta BILL-konto?",
   });
 });

--- a/teknologr/members/templates/member.html
+++ b/teknologr/members/templates/member.html
@@ -234,17 +234,29 @@
           <div class="col-sm-6">
             <h5>BILL</h5>
             {% if member.bill_code %}
+
+            {% if BILL.error %}
+              <div class="alert alert-danger">{{ BILL.error }}</div>
+            {% elif not BILL.exists %}
+              <div class="alert alert-danger">BILL-konto "{{ member.bill_code }}" existerar inte</div>
+            {% endif %}
+
             <b>Konto:</b>
             <span class="monospace">{{ member.bill_code }}</span>
             <br/>
 
-            {% if BILL.error %}
-            <div class="alert alert-danger">{{ BILL.error }}</div>
-            {% else %}
+            {% if BILL.exists %}
             <b>Saldo:</b> {{ BILL.balance }}€
             <br/>
-            <button id="delete-bill-button" class="btn btn-danger" data-id="{{ member.id }}">Ta bort BILL-konto</button>
             {% endif %}
+
+            <button
+              id="delete-bill-button"
+              class="btn btn-danger"
+              data-id="{{ member.id }}"
+              {% if BILL.error %}disabled title="BILL error..."{% endif %}>
+              Ta bort BILL-konto
+            </button>
 
             {% else %}
             <button id="add-bill-button" class="btn btn-primary" {% if not LDAP.exists %} disabled title="Skapa LDAP-konto först"{% endif %} data-id="{{ member.id }}">Skapa BILL-konto</button>

--- a/teknologr/members/templates/member.html
+++ b/teknologr/members/templates/member.html
@@ -212,7 +212,7 @@
               class="btn btn-danger"
               data-id="{{ member.id }}"
               {% if LDAP.error %}disabled title="LDAP error..."{% endif %}>
-              Ta bort LDAP konto
+              Ta bort LDAP-konto
             </button>
 
             {% else %}
@@ -221,9 +221,9 @@
               class="btn btn-primary"
               data-toggle="modal"
               data-target="#addldap_modal">
-              Skapa LDAP konto
+              Skapa LDAP-konto
             </button>
-            {% include "modals/ldap_add.html" with modalname="addldap_modal" title="Skapa LDAP konto" member_id=member.id only %}
+            {% include "modals/ldap_add.html" with modalname="addldap_modal" title="Skapa LDAP-konto" member_id=member.id only %}
 
             {% endif %}
           </div>
@@ -239,11 +239,11 @@
             {% else %}
             <b>Saldo:</b> {{ BILL.balance }}€
             <br/>
-            <button id="delete-bill-button" class="btn btn-danger" data-id="{{ member.id }}">Ta bort BILL konto</button>
+            <button id="delete-bill-button" class="btn btn-danger" data-id="{{ member.id }}">Ta bort BILL-konto</button>
             {% endif %}
 
             {% else %}
-            <button id="add-bill-button" class="btn btn-primary" {% if not LDAP.exists %} disabled title="Skapa LDAP konto först"{% endif %} data-id="{{ member.id }}">Skapa BILL konto</button>
+            <button id="add-bill-button" class="btn btn-primary" {% if not LDAP.exists %} disabled title="Skapa LDAP-konto först"{% endif %} data-id="{{ member.id }}">Skapa BILL-konto</button>
             {% endif %}
           </div>
         </div>

--- a/teknologr/members/templates/member.html
+++ b/teknologr/members/templates/member.html
@@ -185,26 +185,46 @@
           <div class="col-sm-6">
             <h5>LDAP</h5>
             {% if member.username %}
-            <b>Användarnamn:</b> <span class="monospace">{{ member.username }}</span>
-            <br/>
 
             {% if LDAP.error %}
-            <div class="alert alert-danger">{{ LDAP.error }}</div>
-            {% else %}
+              <div class="alert alert-danger">{{ LDAP.error }}</div>
+            {% elif not LDAP.exists %}
+              <div class="alert alert-danger">LDAP-konto "{{ member.username }}" existerar inte</div>
+            {% endif %}
+            <b>Användarnamn:</b> <span class="monospace">{{ member.username }}</span>
+            <br/>
             <b>Grupper:</b>
             <ul>
               {% for group in LDAP.groups %}
               <li>{{ group }}</li>
               {% endfor %}
             </ul>
-            <button class="btn btn-primary" data-toggle="modal" data-target="#changepw_modal">Ändra lösenord</button>
+            <button
+              class="btn btn-primary"
+              data-toggle="modal"
+              data-target="#changepw_modal"
+              {% if not LDAP.exists %}disabled title="LDAP-konto existerar inte"{% endif %}>
+              Ändra lösenord
+            </button>
             {% include "modals/ldap_changepw.html" with modalname="changepw_modal" title="Ändra LDAP lösenord" member_id=member.id only %}
-            <button id="delete-ldap-button" class="btn btn-danger" data-id="{{ member.id }}">Ta bort LDAP konto</button>
-            {% endif %}
+            <button
+              id="delete-ldap-button"
+              class="btn btn-danger"
+              data-id="{{ member.id }}"
+              {% if LDAP.error %}disabled title="LDAP error..."{% endif %}>
+              Ta bort LDAP konto
+            </button>
 
             {% else %}
-            <button class="btn btn-primary" data-toggle="modal" data-target="#addldap_modal">Skapa LDAP konto</button>
+
+            <button
+              class="btn btn-primary"
+              data-toggle="modal"
+              data-target="#addldap_modal">
+              Skapa LDAP konto
+            </button>
             {% include "modals/ldap_add.html" with modalname="addldap_modal" title="Skapa LDAP konto" member_id=member.id only %}
+
             {% endif %}
           </div>
           <div class="col-sm-6">
@@ -223,7 +243,7 @@
             {% endif %}
 
             {% else %}
-            <button id="add-bill-button" class="btn btn-primary" {% if not LDAP %} disabled title="Skapa LDAP konto först"{% endif %} data-id="{{ member.id }}">Skapa BILL konto</button>
+            <button id="add-bill-button" class="btn btn-primary" {% if not LDAP.exists %} disabled title="Skapa LDAP konto först"{% endif %} data-id="{{ member.id }}">Skapa BILL konto</button>
             {% endif %}
           </div>
         </div>

--- a/teknologr/members/templates/member.html
+++ b/teknologr/members/templates/member.html
@@ -211,7 +211,11 @@
               id="delete-ldap-button"
               class="btn btn-danger"
               data-id="{{ member.id }}"
-              {% if LDAP.error %}disabled title="LDAP error..."{% endif %}>
+              {% if LDAP.error %}
+              disabled title="LDAP error..."
+              {% elif member.bill_code %}
+              disabled title="Ta bort BILL-konto först"
+              {% endif %}>
               Ta bort LDAP-konto
             </button>
 

--- a/teknologr/members/tests_models.py
+++ b/teknologr/members/tests_models.py
@@ -217,19 +217,6 @@ class MemberTest(TestCase):
         self.assertEquals('StÄlM', member.current_member_type)
         self.assertFalse(member.shouldBeStalm())
 
-    def test_saving(self):
-        member = Member(
-            given_names='Svatta',
-            surname='Teknolog',
-        )
-        member.save()
-
-        # try to cover lines missed by conditions.
-        member.username = 'teknosv1'
-        member.student_id = '123456'
-        member.email = 'svatta@teknolog.fi'
-        member.save()
-
 
 class MemberOrderTest(BaseTest):
     def test_order_by(self):

--- a/teknologr/members/tests_models.py
+++ b/teknologr/members/tests_models.py
@@ -228,8 +228,7 @@ class MemberTest(TestCase):
         member.username = 'teknosv1'
         member.student_id = '123456'
         member.email = 'svatta@teknolog.fi'
-        with self.assertRaises(LDAPError):
-            member.save()
+        member.save()
 
 
 class MemberOrderTest(BaseTest):

--- a/teknologr/members/views.py
+++ b/teknologr/members/views.py
@@ -76,10 +76,11 @@ def member(request, member_id):
         form = MemberForm(request.POST, instance=member)
         if form.is_valid():
             from ldap import LDAPError
+            from api.ldap import LDAPError_to_string
             try:
                 form.save()
-            except LDAPError:
-                form.add_error("email", "Could not sync to LDAP")
+            except LDAPError as e:
+                form.add_error('email', f'Could not sync to LDAP: {LDAPError_to_string(e)}')
             context['result'] = 'success'
         else:
             context['result'] = 'failure'

--- a/teknologr/members/views.py
+++ b/teknologr/members/views.py
@@ -7,6 +7,7 @@ from members.programmes import DEGREE_PROGRAMME_CHOICES
 from registration.models import Applicant
 from registration.forms import RegistrationForm
 from api.ldap import get_ldap_account
+from api.bill import BILLAccountManager
 from getenv import env
 from locale import strxfrm
 
@@ -118,18 +119,12 @@ def member(request, member_id):
         context['LDAP'] = get_ldap_account(member.username)
 
     if member.bill_code:
-        from api.bill import BILLAccountManager, BILLException
         bm = BILLAccountManager()
-        try:
-            context['bill_admin_url'] = bm.admin_url(member.bill_code)
-            context['BILL'] = bm.get_bill_info(member.bill_code)
-
-            # Check that the username stored by BILL is the same as our
-            username = context['BILL']['id']
-            if member.username != username:
-                context['BILL']['error'] = f'LDAP användarnamnen här ({member.username}) och i BILL ({username}) matchar inte'
-        except BILLException as e:
-            context['BILL'] = {'error': e}
+        context['bill_admin_url'] = bm.admin_url(member.bill_code)
+        context['BILL'] = bm.get_bill_info(member.bill_code)
+        username = context['BILL'].get('id')
+        if username and member.username != username:
+            context['BILL']['error'] = f'LDAP användarnamnen här ({member.username}) och i BILL ({username}) matchar inte'
 
     # load side list items
     set_side_context(context, 'members', member)

--- a/teknologr/members/views.py
+++ b/teknologr/members/views.py
@@ -6,6 +6,7 @@ from members.forms import *
 from members.programmes import DEGREE_PROGRAMME_CHOICES
 from registration.models import Applicant
 from registration.forms import RegistrationForm
+from api.ldap import get_ldap_account
 from getenv import env
 from locale import strxfrm
 
@@ -113,16 +114,7 @@ def member(request, member_id):
 
     # Get user account info
     if member.username:
-        from api.ldap import LDAPAccountManager, LDAPError_to_string
-        try:
-            with LDAPAccountManager() as lm:
-                # Separately check that the LDAP account exists, because get_ldap_groups does not do that
-                context['LDAP'] = {
-                    'exists': lm.check_account(member.username),
-                    'groups': lm.get_ldap_groups(member.username),
-                }
-        except Exception as e:
-            context['LDAP'] = {'error': LDAPError_to_string(e)}
+        context['LDAP'] = get_ldap_account(member.username)
 
     if member.bill_code:
         from api.bill import BILLAccountManager, BILLException

--- a/teknologr/members/views.py
+++ b/teknologr/members/views.py
@@ -116,7 +116,11 @@ def member(request, member_id):
         from api.ldap import LDAPAccountManager, LDAPError_to_string
         try:
             with LDAPAccountManager() as lm:
-                context['LDAP'] = {'groups': lm.get_ldap_groups(member.username)}
+                # Separately check that the LDAP account exists, because get_ldap_groups does not do that
+                context['LDAP'] = {
+                    'exists': lm.check_account(member.username),
+                    'groups': lm.get_ldap_groups(member.username),
+                }
         except Exception as e:
             context['LDAP'] = {'error': LDAPError_to_string(e)}
 


### PR DESCRIPTION
Fixed bug where a Member could have a username that referred to a non-existent LDAP account, making it impossible to 1) change email, 2) delete/modify the LDAP-account and 3) create BILL account. Added a separate check to see if an LDAP-account exists, and making it possible to just remove the username from the Member if the LDAP-account does not exist. This resolves issue #186.

Fixed the same bug on the BILL side, where a Member could have a BILL account number referring to a non-existent BILL-code. This resolves issue #187.